### PR TITLE
Support compilation on macOS using rhub

### DIFF
--- a/src/wgt_jaccard.cpp
+++ b/src/wgt_jaccard.cpp
@@ -109,7 +109,8 @@ Rcpp::List wgt_jaccard(
 
     #pragma omp parallel for schedule(dynamic)
     for(int i=0; i < y.size(); i++){
-        tokenizer tokens(y(i), sep);
+        std::string s{y(i)};
+        tokenizer tokens(s, sep);
         // create vector to store words
         auto y_token_vector = std::vector<std::string>(tokens.begin(), tokens.end());
         std::sort(y_token_vector.begin(), y_token_vector.end());
@@ -130,7 +131,8 @@ Rcpp::List wgt_jaccard(
         }
 
         // split the company name
-        tokenizer tokens(x(i), sep);
+        std::string s{x(i)};
+        tokenizer tokens(s, sep);
         // create vector to store words
         auto x_tok_vec = std::vector<std::string>(tokens.begin(), tokens.end());
         std::sort(x_tok_vec.begin(), x_tok_vec.end());

--- a/src/wgt_jaccard.cpp
+++ b/src/wgt_jaccard.cpp
@@ -5,7 +5,9 @@
 #include <algorithm>
 #include <string>
 #include <unordered_map>
-#include <omp.h>
+#ifdef _OPENMP
+  #include <omp.h>
+#endif
 #include <vector>
 
 // [[Rcpp::depends(BH)]]


### PR DESCRIPTION
The PR contains two short commits which in sum permit the compilation at the macOS machine of [rhub](https://builder.r-hub.io/).  It addressed the puzzle presented in [this StackOverflow](https://stackoverflow.com/q/68567416/143305) question.

We change two things:
- do not include `omp.h` unconditionally as macOS machine may, or may not, have OpenMP
- do not pass an Rcpp::StringVector object to the the Boost `tokenizer` but take an intermediate step via a `std::string`

One resulting pass is [see here](https://builder.r-hub.io/status/fedmatch_2.0.1.1.tar.gz-42ba6565a2be4de4929f2584e2043cdb) (at least they delete it after a few days).  Ignore that I changed the version to 2.0.1.1, that is just a personal habit of making altered tarballs show a different version.